### PR TITLE
Changed port to 8080

### DIFF
--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -83,7 +83,7 @@ Librarian::
 
     $ librarian --conf /etc/librarian.ini
 
-Within less than a minute, the server will start responding on the port 80.
+Within less than a minute, the server will start responding on the port 8080.
 
 Detaching from the screen session
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
In e1d5585df6 the Librarian port was changed from 80 to 8080.
Changing documentation to match.